### PR TITLE
Pin grunt to version 0.4 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "4"
 before_script:
-  - npm install grunt-cli grunt grunt-saucelabs grunt-contrib-connect grunt-contrib-watch
+  - npm install grunt-cli grunt@0.4 grunt-saucelabs grunt-contrib-connect grunt-contrib-watch
   - npm install coveralls html-webpack-plugin webpack ecstatic
   - webpack --config webpack.test.js
 script:


### PR DESCRIPTION
npm install grunt now installs version 1, which breaks a peer-dependency with grunt-saucelabs
